### PR TITLE
Fix caption position on portfolio images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -154,9 +154,9 @@ button:hover {
 
 .image-description {
   position: absolute;
-  top: 50%;
+  top: 10px;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   color: #fff;
   font-size: 1.5rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- adjust position of `.image-description` so captions appear near top of image when hovering

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685866d29afc8332bfda4a507600e1c0