### PR TITLE
Add date placeholders to portfolio images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -176,6 +176,22 @@ button:hover {
 .image-container:hover .image-description {
   opacity: 1;
 }
+.image-date {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-size: 1rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  text-shadow: 2px 2px 5px rgba(0, 0, 0, 0.7);
+}
+
+.image-container:hover .image-date {
+  opacity: 1;
+}
+
 
 .modal {
   display: none;

--- a/portfolio.md
+++ b/portfolio.md
@@ -7,132 +7,164 @@ permalink: /portfolio/
 <div class="image-container">
   <img src="/assets/images/6-5.jpg" alt="Campanile at Sunset II" onclick="openModal(this)">
   <div class="image-description">Campanile at Sunset II</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/416-2.jpg" alt="Golden Gate from Baker Beach" onclick="openModal(this)">
   <div class="image-description">Golden Gate from Baker Beach</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/7-2.jpg" alt="Martinez Waterfront" onclick="openModal(this)">
   <div class="image-description">Martinez Waterfront</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/6-1.jpg" alt="Truck" onclick="openModal(this)">
   <div class="image-description">Truck</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/7-3.jpg" alt="Muir's Poppies" onclick="openModal(this)">
   <div class="image-description">Muir's Poppies</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/416-1.jpg" alt="Wilhelmina" onclick="openModal(this)">
   <div class="image-description">Wilhelmina</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/6-4.jpg" alt="Dark-eyed Junco" onclick="openModal(this)">
   <div class="image-description">Dark-eyed Junco</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/7-1.jpg" alt="Sand Crew" onclick="openModal(this)">
   <div class="image-description">Sand Crew</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/6-3.jpg" alt="Berkeley Rose Garden" onclick="openModal(this)">
   <div class="image-description">Berkeley Rose Garden</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/6-6.jpg" alt="Fishing" onclick="openModal(this)">
   <div class="image-description">Fishing</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/6-2.jpg" alt="Elmwood Patterns" onclick="openModal(this)">
   <div class="image-description">Elmwood Patterns</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/4-3.jpg" alt="Sutro Tower from Alamo Square" onclick="openModal(this)">
   <div class="image-description">Sutro Tower from Alamo Square</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/4-4.jpg" alt="Painted Ladies" onclick="openModal(this)">
   <div class="image-description">Painted Ladies</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/4-2.jpg" alt="Dog at Alamo Square" onclick="openModal(this)">
   <div class="image-description">Dog at Alamo Square</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/5-1.jpg" alt="American Robin" onclick="openModal(this)">
   <div class="image-description">American Robin</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/4-1.jpg" alt="Ocean Beach at Sunset" onclick="openModal(this)">
   <div class="image-description">Ocean Beach at sunset</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/IMG_1175.jpg" alt="Golden Gate Bridge" onclick="openModal(this)">
   <div class="image-description">Golden Gate Bridge</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/IMG_1044.jpg" alt="Sutro Tower from the Sunset" onclick="openModal(this)">
   <div class="image-description">Sutro Tower from the Sunset</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/3.jpg" alt="Campanile at Sunset" onclick="openModal(this)">
   <div class="image-description">Campanile at sunset</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/IMG_1120.jpg" alt="Mallard Duck on a Log" onclick="openModal(this)">
   <div class="image-description">Mallard duck on a log</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/IMG_1060.jpg" alt="Mallard duck stretching" onclick="openModal(this)">
   <div class="image-description">Mallard duck Stretching</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 
 <h2>Shot on Canon Powershot SX20 IS</h2>
 <div class="image-container">
   <img src="/assets/images/2-01.jpg" alt="Elmwood Theater" onclick="openModal(this)">
   <div class="image-description">Elmwood Theater</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-03.jpg" alt="Big Game 2024" onclick="openModal(this)">
   <div class="image-description">Big Game 2024</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-04.jpg" alt="Crepevine" onclick="openModal(this)">
   <div class="image-description">Crepevine</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-05.jpg" alt="Game Day 2024" onclick="openModal(this)">
   <div class="image-description">Game Day 2024</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-02.jpg" alt="Pacifica Coastline" onclick="openModal(this)">
   <div class="image-description">Pacifica Coastline</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-06.jpg" alt="Silhouette of a Bird" onclick="openModal(this)">
   <div class="image-description">Silhouette of a Bird</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-07.jpg" alt="Flower and Bridge" onclick="openModal(this)">
   <div class="image-description">Flower and Bridge</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-08.jpg" alt="Horse Painting" onclick="openModal(this)">
   <div class="image-description">Horse Painting</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-09.jpg" alt="RFS 450" onclick="openModal(this)">
   <div class="image-description">RFS 450</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-10.jpg" alt="Hillsdale" onclick="openModal(this)">
   <div class="image-description">Hillsdale</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 <div class="image-container">
   <img src="/assets/images/2-11.jpg" alt="Moe's Books" onclick="openModal(this)">
   <div class="image-description">Moe's Books</div>
+  <div class="image-date">MM/DD/YYYY</div>
 </div>
 
 <!-- Modal for full-screen image -->


### PR DESCRIPTION
## Summary
- allow specifying a date for each photo
- style `.image-date` overlay so it appears on hover

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e342658948332a7fb8958d264e36b