### PR TITLE
fix: correct rights reserved typo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
   </main>
 
 <footer>
-  <p>© 2025 jerrickwang.github.io | all aights reserved</p>
+  <p>© 2025 jerrickwang.github.io | all rights reserved</p>
   <a href="https://instagram.com/majorwangpics" target="_blank" rel="noopener noreferrer">
     <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram" style="height: 20px;">
   </a>

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -38,7 +38,7 @@
   </div>
 
 <footer>
-  <p>© 2025 jerrickwang.github.io | all aights reserved</p>
+  <p>© 2025 jerrickwang.github.io | all rights reserved</p>
   <a href="https://instagram.com/majorwangpics" target="_blank" rel="noopener noreferrer">
     <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram" style="height: 20px;">
   </a>


### PR DESCRIPTION
## Summary
- fix "all aights reserved" typo in default and wide layout footers

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_688f28f060408332b4d0194ad7e07ca6