### PR TITLE
style: center portfolio section headers

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -89,6 +89,10 @@ header h1 {
   color: #333;
 }
 
+h2 {
+  text-align: center;
+}
+
 main {
   max-width: 1200px;
   width: 100%;


### PR DESCRIPTION
## Summary
- center portfolio section headers by globally aligning `<h2>` elements in CSS

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_689abf3c3b748332bfd4d4b6a5682c4b