### PR TITLE
Center portfolio image rows

### DIFF
--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -27,7 +27,7 @@
     <h1>{{ page.title }}</h1>
   </header>
 
-  <main style="max-width: 95%; margin: 0 auto;">
+  <main style="max-width: 95%; margin: 0 auto; text-align: center;">
     {{ content }}
   </main>
 


### PR DESCRIPTION
## Summary
- Center portfolio content so image rows align in the middle of the page

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689ac3009d48833293fa477a86360f96