### PR TITLE
Set uniform 250px height for images

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
 <footer>
   <p>© 2025 jerrickwang.github.io | all rights reserved</p>
   <a href="https://instagram.com/majorwangpics" target="_blank" rel="noopener noreferrer">
-    <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram" style="height: 20px;">
+    <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram">
   </a>
 </footer>
 

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -40,7 +40,7 @@
 <footer>
   <p>© 2025 jerrickwang.github.io | all rights reserved</p>
   <a href="https://instagram.com/majorwangpics" target="_blank" rel="noopener noreferrer">
-    <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram" style="height: 20px;">
+    <img src="{{ '/assets/instagram.svg' | relative_url }}" alt="Instagram">
   </a>
 </footer>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -39,7 +39,7 @@ nav {
 }
 
 .logo img {
-  height: 50px;
+  height: 250px;
   width: auto;
   margin-right: 10px;
 }
@@ -112,7 +112,7 @@ footer {
 
 img {
   max-width: 100%;
-  height: auto;
+  height: 250px;
   display: block;
   margin: 0 auto;
 }
@@ -147,9 +147,8 @@ button:hover {
 
 .image-container img {
   max-width: 500px;
-  max-height: 400px;
   width: auto;
-  height: auto;
+  height: 250px;
   display: block;
   margin: 0 auto;
   cursor: pointer;
@@ -283,7 +282,7 @@ button:hover {
 
   .image-container img {
     max-width: 100%;
-    max-height: 300px;
+    height: 250px;
   }
 
   header h1 {


### PR DESCRIPTION
## Summary
- Force all images to render at 250px tall through global CSS rules
- Remove inline height overrides in default and wide layouts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ad1c524ac8332951ae868a9e163f7