### PR TITLE
Set portfolio photos to fixed height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -146,10 +146,8 @@ button:hover {
 }
 
 .image-container img {
-  max-width: 500px;
-  max-height: 400px;
+  height: 400px;
   width: auto;
-  height: auto;
   display: block;
   margin: 0 auto;
   cursor: pointer;
@@ -283,7 +281,7 @@ button:hover {
 
   .image-container img {
     max-width: 100%;
-    max-height: 300px;
+    height: 300px;
   }
 
   header h1 {


### PR DESCRIPTION
## Summary
- ensure portfolio page photos render at a fixed height of 400px
- keep social icons untouched and adjust mobile styling for consistency

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: tunnel error while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689d4559d5c8833282824c77c7424d92