### PR TITLE
Set portfolio photos to fixed height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -146,10 +146,9 @@ button:hover {
 }
 
 .image-container img {
-  max-width: 500px;
-  max-height: 400px;
-  width: auto;
-  height: auto;
+  height: 400px;
+  width: 100%;
+  object-fit: cover;
   display: block;
   margin: 0 auto;
   cursor: pointer;
@@ -282,8 +281,9 @@ button:hover {
   }
 
   .image-container img {
-    max-width: 100%;
-    max-height: 300px;
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
   }
 
   header h1 {


### PR DESCRIPTION
## Summary
- ensure portfolio page photos render at a fixed height of 400px
- keep social icons untouched and adjust mobile styling for consistency
- prevent stretching on mobile with `object-fit: cover` and full-width sizing

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689d4559d5c8833282824c77c7424d92