### PR TITLE
Fix stretched images on mobile portfolio

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -280,8 +280,8 @@ button:hover {
   }
 
   .image-container img {
-    max-width: 100%;
-    height: 300px;
+    width: 100%;
+    height: auto;
   }
 
   header h1 {


### PR DESCRIPTION
## Summary
- ensure portfolio images scale proportionally on small screens by removing fixed height

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689d4ae798fc8332a5ead9caaf9c6ca5