### PR TITLE
Add carousel navigation in image modal

### DIFF
--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -32,9 +32,9 @@
   </main>
 
   <!-- Modal for full-screen image -->
-  <div id="imageModal" style="display: none;">
-    <span id="close" style="font-size: 30px; cursor: pointer;">&times;</span>
-    <img id="modalImage" src="" alt="Modal Image" />
+  <div id="imageModal" class="modal">
+    <span id="close" class="close">&times;</span>
+    <img id="modalImage" class="modal-content" src="" alt="Modal Image" />
   </div>
 
 <footer>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,29 +1,73 @@
+var images = [];
+var currentIndex = 0;
+
 function openModal(imageElement) {
-  console.log('Modal is opening'); 
+  images = Array.from(document.querySelectorAll('img[onclick="openModal(this)"]'));
+  currentIndex = images.indexOf(imageElement);
 
   var modal = document.getElementById("imageModal");
-  var modalImage = document.getElementById("modalImage");
-  
-  if (modal && modalImage) {
+  if (modal) {
     modal.style.display = "block";
-    modalImage.src = imageElement.src;
+    showImage(currentIndex);
   } else {
-    console.error('Modal or Modal Image element not found!');
+    console.error('Modal element not found!');
   }
 }
 
-function closeModal(event) {
-  var modal = document.getElementById("imageModal");
-  var modalImage = document.getElementById("modalImage");
+function showImage(index) {
+  if (images.length === 0) return;
 
-  if (event.target === modal || event.target === modalImage || event.target === document.getElementById("close")) {
+  if (index < 0) {
+    index = images.length - 1;
+  } else if (index >= images.length) {
+    index = 0;
+  }
+  currentIndex = index;
+
+  var modalImage = document.getElementById("modalImage");
+  if (modalImage) {
+    modalImage.src = images[currentIndex].src;
+  } else {
+    console.error('Modal Image element not found!');
+  }
+}
+
+function showNext() {
+  showImage(currentIndex + 1);
+}
+
+function showPrev() {
+  showImage(currentIndex - 1);
+}
+
+function closeModal() {
+  var modal = document.getElementById("imageModal");
+  if (modal) {
     modal.style.display = "none";
+  }
+}
+
+function handleModalClick(event) {
+  if (event.target.id === "close") {
+    closeModal();
+    return;
+  }
+
+  var width = window.innerWidth;
+  var x = event.clientX;
+
+  if (x < width * 0.1) {
+    showPrev();
+  } else if (x > width * 0.9) {
+    showNext();
+  } else {
+    closeModal();
   }
 }
 
 var modal = document.getElementById("imageModal");
 if (modal) {
-  modal.addEventListener("click", closeModal);
+  modal.addEventListener("click", handleModalClick);
 } else {
   console.error('Modal element not found!');
 }

--- a/portfolio.md
+++ b/portfolio.md
@@ -177,8 +177,3 @@ permalink: /portfolio/
   <div class="image-date">April 2024</div>
 </div>
 
-<!-- Modal for full-screen image -->
-<div id="imageModal" class="modal" onclick="closeModal()">
-  <span class="close">&times;</span>
-  <img class="modal-content" id="modalImage">
-</div>


### PR DESCRIPTION
## Summary
- Enable fullscreen images to navigate like a carousel by clicking left or right edges
- Centralize modal markup in layout and remove redundant portfolio modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d4fe03a088332967b6fd06167db75