### PR TITLE
feat: add arrow key navigation to carousel

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -68,6 +68,15 @@ function handleModalClick(event) {
 var modal = document.getElementById("imageModal");
 if (modal) {
   modal.addEventListener("click", handleModalClick);
+  document.addEventListener("keydown", function(event) {
+    if (modal.style.display === "block") {
+      if (event.key === "ArrowRight") {
+        showNext();
+      } else if (event.key === "ArrowLeft") {
+        showPrev();
+      }
+    }
+  });
 } else {
   console.error('Modal element not found!');
 }


### PR DESCRIPTION
## Summary
- allow left/right arrow keys to navigate image carousel

## Testing
- `npm test` *(fails: missing package.json)*
- `jekyll build` *(fails: cannot load such file -- jekyll-seo-tag)*

------
https://chatgpt.com/codex/tasks/task_e_689e935854588332b9ca44367a18c950