### PR TITLE
Add navigation arrows to carousel modal

### DIFF
--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -34,7 +34,9 @@
   <!-- Modal for full-screen image -->
   <div id="imageModal" class="modal">
     <span id="close" class="close">&times;</span>
+    <span id="prevArrow" class="arrow left">&#10094;</span>
     <img id="modalImage" class="modal-content" src="" alt="Modal Image" />
+    <span id="nextArrow" class="arrow right">&#10095;</span>
   </div>
 
 <footer>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -227,6 +227,25 @@ button:hover {
   cursor: pointer;
 }
 
+.arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 60px;
+  color: #fff;
+  font-weight: bold;
+  user-select: none;
+  cursor: pointer;
+}
+
+.arrow.left {
+  left: 20px;
+}
+
+.arrow.right {
+  right: 20px;
+}
+
 .blog-post-container {
   width: 95%; 
   max-width: 750px;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -68,6 +68,23 @@ function handleModalClick(event) {
 var modal = document.getElementById("imageModal");
 if (modal) {
   modal.addEventListener("click", handleModalClick);
+
+  var prevArrow = document.getElementById("prevArrow");
+  if (prevArrow) {
+    prevArrow.addEventListener("click", function(event) {
+      event.stopPropagation();
+      showPrev();
+    });
+  }
+
+  var nextArrow = document.getElementById("nextArrow");
+  if (nextArrow) {
+    nextArrow.addEventListener("click", function(event) {
+      event.stopPropagation();
+      showNext();
+    });
+  }
+
   document.addEventListener("keydown", function(event) {
     if (modal.style.display === "block") {
       if (event.key === "ArrowRight") {


### PR DESCRIPTION
## Summary
- add visible left and right navigation arrows in the image modal
- style arrows and wire up click handlers to navigate between images

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689e9bdab12c8332820164fb76375b99