### PR TITLE
Animate carousel arrows on navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -246,6 +246,16 @@ button:hover {
   right: 20px;
 }
 
+@keyframes arrow-flash {
+  0% { color: #fff; }
+  50% { color: #000; }
+  100% { color: #fff; }
+}
+
+.arrow.flash {
+  animation: arrow-flash 0.1s ease;
+}
+
 .blog-post-container {
   width: 95%; 
   max-width: 750px;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -35,6 +35,8 @@ function showImage(index) {
 function flashArrow(id) {
   var arrow = document.getElementById(id);
   if (arrow) {
+    arrow.classList.remove("flash");
+    void arrow.offsetWidth;
     arrow.classList.add("flash");
     setTimeout(function() {
       arrow.classList.remove("flash");


### PR DESCRIPTION
## Summary
- Add keyframe animation so carousel arrows briefly flash black when used
- Ensure arrow flash animation restarts on every navigation

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ea2ae50f88332b6320a764a517847