### PR TITLE
Fix arrow flash animation timing

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -38,9 +38,13 @@ function flashArrow(id) {
     arrow.classList.remove("flash");
     void arrow.offsetWidth;
     arrow.classList.add("flash");
-    setTimeout(function() {
+
+    function handleAnimationEnd() {
       arrow.classList.remove("flash");
-    }, 100);
+      arrow.removeEventListener("animationend", handleAnimationEnd);
+    }
+
+    arrow.addEventListener("animationend", handleAnimationEnd);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure modal navigation arrows run full easing animation by removing the `flash` class after `animationend`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eaa0087d4833287600a66a5152354