### PR TITLE
Scale arrows near screen edges

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -236,6 +236,7 @@ button:hover {
   font-weight: bold;
   user-select: none;
   cursor: pointer;
+  transition: transform 0.2s ease;
 }
 
 .arrow.left {
@@ -244,6 +245,10 @@ button:hover {
 
 .arrow.right {
   right: 20px;
+}
+
+.arrow.scaled {
+  transform: translateY(-50%) scale(1.25);
 }
 
 @keyframes arrow-flash {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -63,6 +63,10 @@ function closeModal() {
   if (modal) {
     modal.style.display = "none";
   }
+  var prevArrow = document.getElementById("prevArrow");
+  var nextArrow = document.getElementById("nextArrow");
+  if (prevArrow) prevArrow.classList.remove("scaled");
+  if (nextArrow) nextArrow.classList.remove("scaled");
 }
 
 function handleModalClick(event) {
@@ -83,9 +87,28 @@ function handleModalClick(event) {
   }
 }
 
+function handleMouseMove(event) {
+  var width = window.innerWidth;
+  var x = event.clientX;
+  var prevArrow = document.getElementById("prevArrow");
+  var nextArrow = document.getElementById("nextArrow");
+
+  if (x < width * 0.1) {
+    if (prevArrow) prevArrow.classList.add("scaled");
+    if (nextArrow) nextArrow.classList.remove("scaled");
+  } else if (x > width * 0.9) {
+    if (nextArrow) nextArrow.classList.add("scaled");
+    if (prevArrow) prevArrow.classList.remove("scaled");
+  } else {
+    if (prevArrow) prevArrow.classList.remove("scaled");
+    if (nextArrow) nextArrow.classList.remove("scaled");
+  }
+}
+
 var modal = document.getElementById("imageModal");
 if (modal) {
   modal.addEventListener("click", handleModalClick);
+  modal.addEventListener("mousemove", handleMouseMove);
 
   var prevArrow = document.getElementById("prevArrow");
   if (prevArrow) {


### PR DESCRIPTION
## Summary
- Smoothly scale navigation arrows by 25% when the pointer is in the left or right 10% of the viewport.
- Reset arrow scaling when the modal closes for consistent behavior.

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689eb04b8fc88332b1be188d2cdb0564