### PR TITLE
Align carousel modal caption text to right

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -227,6 +227,7 @@ button:hover {
   border-radius: 5px;
   pointer-events: none;
   font-size: 1rem;
+  text-align: right;
 }
 
 .close {


### PR DESCRIPTION
## Summary
- align image description and date text to the right within carousel modal caption

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a01f28c8408332b2569b6fb989f0ef