### PR TITLE
Use vibrant colors for background animation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,10 +24,10 @@ body::before {
   width: 140%;
   height: 140%;
   background:
-    radial-gradient(circle at 80% 20%, rgba(150, 214, 176, 0.3), transparent 60%),
-    radial-gradient(circle at 20% 80%, rgba(150, 214, 176, 0.25), transparent 60%),
-    radial-gradient(circle at 50% 50%, rgba(150, 214, 176, 0.2), transparent 60%);
-  /*filter: blur(80px);*/
+    radial-gradient(circle at 80% 20%, rgba(255, 0, 0, 0.6), transparent 60%),
+    radial-gradient(circle at 20% 80%, rgba(0, 0, 255, 0.6), transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 0, 0.6), transparent 60%);
+  filter: none;
   z-index: -1;
   animation: ambient-move 60s linear infinite;
 }


### PR DESCRIPTION
## Summary
- Replace green ambient background blobs with vibrant red, blue and yellow gradients
- Disable blur filter for clear debugging visuals

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aab321b7c08332bd54dd8759a15875