### PR TITLE
Ensure animated background fully covers page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -19,10 +19,10 @@ body {
 body::before {
   content: "";
   position: fixed;
-  top: -20%;
-  right: -20%;
-  width: 140%;
-  height: 140%;
+  top: -100%;
+  left: -100%;
+  width: 300%;
+  height: 300%;
   background:
     radial-gradient(circle at 80% 20%, rgba(255, 0, 0, 0.6), transparent 60%),
     radial-gradient(circle at 20% 80%, rgba(0, 0, 255, 0.6), transparent 60%),


### PR DESCRIPTION
## Summary
- Enlarge background pseudo-element so animated colors always cover the viewport

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: tunnel error while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aab700ae888332a96450139d4d0352